### PR TITLE
Replace 'clang' with 'OpenBSD' in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,7 +14,7 @@ still in early stage.
 | openBSD x64 (clang) | No [^1]   |
 | Windows 10 x64      | No [^2]   |
 
-[^1]: clang support seems to be a problem due to the style of programming and
+[^1]: OpenBSD support seems to be a problem due to the style of programming and
 will be addressed as soon as possible.
 [^2]: Windows Support will be addressed once the game is in a more mature
 state. For this matter another branch will be opened, as ncurses support is


### PR DESCRIPTION
clang seems to work on GNU/Linux distributions, but not on BSD